### PR TITLE
Be softer on the requirements of this gem

### DIFF
--- a/twilio_mock.gemspec
+++ b/twilio_mock.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.2'
 
-  s.add_dependency 'twilio-ruby', '~> 5.2.3', '>= 5'
+  s.add_dependency 'twilio-ruby', '~> 5.2'
   s.add_dependency 'webmock', '~> 3.0', '>= 2'
 end


### PR DESCRIPTION
We're using twilio-ruby 5.4.3, but we can't use twilio mock due to the version constraints.