### PR TITLE
loosen requirements for twilio-ruby a bit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     twilio_mock (0.4.0)
-      twilio-ruby (~> 5.2.3, >= 5)
+      twilio-ruby (>= 5)
       webmock (~> 3.0, >= 2)
 
 GEM

--- a/twilio_mock.gemspec
+++ b/twilio_mock.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.2'
 
-  s.add_dependency 'twilio-ruby', '~> 5.2.3', '>= 5'
+  s.add_dependency 'twilio-ruby', '>= 5'
   s.add_dependency 'webmock', '~> 3.0', '>= 2'
 end


### PR DESCRIPTION
I want to be able to use this gem with newer versions of `twilio-ruby`. This PR loosens the requirements a bit to support `twilo-ruby >= 5.0`