### PR TITLE
Fix twilio ruby version to 5.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     twilio_mock (0.4.1)
-      twilio-ruby (>= 5)
+      twilio-ruby (~> 5.3.1, >= 5)
       webmock (~> 3.0, >= 2)
 
 GEM
@@ -14,14 +14,14 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
-    faraday (0.13.1)
+    faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
-    hashdiff (0.3.6)
+    hashdiff (0.3.7)
     json (2.1.0)
     jwt (1.5.6)
-    libxml-ruby (3.0.0)
+    libxml-ruby (3.1.0)
     multipart-post (2.0.0)
-    public_suffix (3.0.0)
+    public_suffix (3.0.2)
     rake (11.3.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -42,11 +42,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    twilio-ruby (5.3.0)
+    twilio-ruby (5.3.1)
       faraday (~> 0.9)
       jwt (~> 1.5)
       libxml-ruby (>= 2.0, < 4.0)
-    webmock (3.0.1)
+    webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/twilio_mock.gemspec
+++ b/twilio_mock.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.2'
 
-  s.add_dependency 'twilio-ruby', '>= 5'
+  s.add_dependency 'twilio-ruby', '~> 5.3.1', '>= 5'
   s.add_dependency 'webmock', '~> 3.0', '>= 2'
 end


### PR DESCRIPTION
Twilio ruby 5.3.0 was dropped by mistake and fixed in 5.3.1: https://github.com/twilio/twilio-ruby/issues/349

Resolves #11 