### PR TITLE
Remove pinned patch level version of twilio-ruby gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     twilio_mock (0.4.2)
-      twilio-ruby (~> 5.3.1, >= 5)
+      twilio-ruby (~> 5.3, >= 5.3.1)
       webmock (~> 3.0, >= 2)
 
 GEM
@@ -18,9 +18,11 @@ GEM
       multipart-post (>= 1.2, < 3)
     hashdiff (0.3.7)
     json (2.1.0)
-    jwt (1.5.6)
-    libxml-ruby (3.1.0)
+    jwt (2.1.0)
+    mini_portile2 (2.3.0)
     multipart-post (2.0.0)
+    nokogiri (1.8.4)
+      mini_portile2 (~> 2.3.0)
     public_suffix (3.0.2)
     rake (11.3.0)
     rspec (3.6.0)
@@ -42,10 +44,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    twilio-ruby (5.3.1)
+    twilio-ruby (5.12.0)
       faraday (~> 0.9)
-      jwt (~> 1.5)
-      libxml-ruby (>= 2.0, < 4.0)
+      jwt (>= 1.5, <= 2.5)
+      nokogiri (>= 1.6, < 2.0)
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -61,4 +63,4 @@ DEPENDENCIES
   twilio_mock!
 
 BUNDLED WITH
-   1.14.5
+   1.16.3

--- a/twilio_mock.gemspec
+++ b/twilio_mock.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.2'
 
-  s.add_dependency 'twilio-ruby', '~> 5.3.1', '>= 5'
+  s.add_dependency 'twilio-ruby', '~> 5.3', '>= 5.3.1'
   s.add_dependency 'webmock', '~> 3.0', '>= 2'
 end


### PR DESCRIPTION
The change made in https://github.com/MaicolBen/twilio_mock/commit/4ed47f9aae4e16c3d13413295c15c4c1955eb980 resulted in our own version of `twilio-ruby` reverting from `5.11.1` to `5.3.1`, due to the `~> 5.3.1` pin in this gem.

Can this be changed to `~> 5.3, >= 5.3.1` to allow people using this gem to have a higher version of `twilio-ruby`?